### PR TITLE
Ensure the div in a NavGroup also has a key

### DIFF
--- a/livedoc-ui-webjar/src/components/doc/nav/NavGroup.jsx
+++ b/livedoc-ui-webjar/src/components/doc/nav/NavGroup.jsx
@@ -25,7 +25,7 @@ export const NavGroup = (props: NavGroupProps) => {
   let items = [];
 
   if (props.group.name) {
-    items.push(<div className="group-title">{props.group.name}</div>);
+    items.push(<div key="-1" className="group-title">{props.group.name}</div>);
     // items.push(<hr />);
   }
 


### PR DESCRIPTION
Fixes this warning:

Warning: Each child in an array or iterator should have a unique "key"
prop. See https://fb.me/react-warning-keys for more information.
    in NavGroup (at NavSection.jsx:15)